### PR TITLE
Update types.go documentation to allow ExternalDNS in Address field.

### DIFF
--- a/core/v1/types.go
+++ b/core/v1/types.go
@@ -6302,7 +6302,7 @@ const (
 
 // NodeAddress contains information for the node's address.
 type NodeAddress struct {
-	// Node address type, one of Hostname, ExternalIP or InternalIP.
+	// Node address type, one of Hostname, ExternalIP, ExternalDNS or InternalIP.
 	Type NodeAddressType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=NodeAddressType"`
 	// The node address.
 	Address string `json:"address" protobuf:"bytes,2,opt,name=address"`


### PR DESCRIPTION
I noticed that Agones makes use of this feature [here](https://github.com/googleforgames/agones/blob/02e57babccab6489b18d956286152174fe9a1eaa/pkg/gameservers/gameservers.go#L46) but it seems rather undocumented.
